### PR TITLE
Memory history goForward fixed

### DIFF
--- a/modules/__tests__/describeHistory.js
+++ b/modules/__tests__/describeHistory.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import expect from 'expect';
-import { PUSH, REPLACE } from '../Actions';
+import { PUSH, REPLACE, POP } from '../Actions';
 
 function describeHistory(createHistory) {
   describe('when the user confirms a transition', function () {
@@ -135,6 +135,7 @@ function describeHistory(createHistory) {
   describe.skip('goBack', function () {
     var history, unlisten;
     beforeEach(function () {
+      window.history.replaceState(null, null, '/');
       history = createHistory();
     });
 
@@ -154,11 +155,66 @@ function describeHistory(createHistory) {
           expect(location.state).toEqual({ the: 'state' });
           expect(location.pathname).toEqual('/two');
           expect(location.search).toEqual('?a=query');
+          expect(location.action).toEqual(PUSH);
           history.goBack();
         },
         function (location) {
+          expect(location.action).toEqual(POP);
           expect(initialLocation).toEqual(location);
           done();
+        }
+      ];
+
+      function execNextStep() {
+        try {
+          steps.shift().apply(this, arguments);
+        } catch (error) {
+          done(error);
+        }
+      }
+
+      unlisten = history.listen(execNextStep);
+    });
+  });
+
+  describe.skip('goForward', function () {
+    var history, unlisten;
+    beforeEach(function () {
+      window.history.replaceState(null, null, '/');
+      history = createHistory();
+    });
+
+    afterEach(function () {
+      if (unlisten)
+        unlisten();
+    });
+
+    it('calls change listeners with the previous location', function (done) {
+      var initialLocation, nextLocation;
+      var steps = [
+        function (location) {
+          initialLocation = location;
+          history.pushState({ the: 'state' }, '/two?a=query');
+        },
+        function (location) {
+          nextLocation = location;
+          expect(location.state).toEqual({ the: 'state' });
+          expect(location.pathname).toEqual('/two');
+          expect(location.search).toEqual('?a=query');
+          expect(location.action).toEqual(PUSH);
+          history.goBack();
+        },
+        function (location) {
+          expect(location.action).toEqual(POP);
+          expect(initialLocation).toEqual(location);
+          history.goForward();
+        },
+        function (location) {
+          console.log(nextLocation, location);
+          const nextLocationPop = { ...nextLocation, action: POP };
+          console.log(nextLocationPop);
+          expect(nextLocationPop).toEqual(location);
+          done()
         }
       ];
 

--- a/modules/__tests__/describeHistory.js
+++ b/modules/__tests__/describeHistory.js
@@ -210,9 +210,7 @@ function describeHistory(createHistory) {
           history.goForward();
         },
         function (location) {
-          console.log(nextLocation, location);
           const nextLocationPop = { ...nextLocation, action: POP };
-          console.log(nextLocationPop);
           expect(nextLocationPop).toEqual(location);
           done()
         }

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -40,7 +40,7 @@ function createMemoryHistory(options={}) {
     var key = history.createKey();
 
     if (typeof entry === 'string')
-      return { path: entry, key };
+      return { pathname: entry, key };
 
     if (typeof entry === 'object' && entry)
       return { ...entry, key };
@@ -73,9 +73,9 @@ function createMemoryHistory(options={}) {
   }
 
   function getCurrentLocation() {
-    var { key, path } = entries[current];
+    var { key, pathname, search } = entries[current];
     var state = readState(key);
-    return createLocation(key, state, path);
+    return createLocation(key, state, pathname + search);
   }
 
   function canGo(n) {
@@ -93,7 +93,9 @@ function createMemoryHistory(options={}) {
 
       current += n;
 
-      history.transitionTo(getCurrentLocation());
+      const currentLocation = getCurrentLocation();
+      // change action to POP
+      history.transitionTo({ ...currentLocation, action: POP });
     }
   }
 
@@ -102,6 +104,7 @@ function createMemoryHistory(options={}) {
       case PUSH:
         current += 1;
         // fall through
+        entries.push(location);
       case REPLACE:
         saveState(location.key, location.state);
         break;


### PR DESCRIPTION
Push state was not saving state to entries so `goForward()` always failed on index check.