### PR TITLE
Browser history goBack/goForward fix

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -1,5 +1,5 @@
 import { PUSH, REPLACE, POP } from './Actions';
-import { addEventListener, removeEventListener, readState, getWindowPath, go } from './DOMUtils';
+import { addEventListener, removeEventListener, readState, saveState, getWindowPath, go } from './DOMUtils';
 import createDOMHistory from './createDOMHistory';
 import createLocation from './createLocation';
 
@@ -38,18 +38,17 @@ function startPopStateListener({ transitionTo }) {
 }
 
 function finishTransition(location) {
-  var { key, pathname, search } = location;
+  var { key, pathname, search, state } = location;
   var path = pathname + search;
-  var state = {
-    key
-  };
 
   switch (location.action) {
     case PUSH:
-      window.history.pushState(state, null, path);
+      saveState(key, state);
+      window.history.pushState({ key }, null, path);
       break;
     case REPLACE:
-      window.history.replaceState(state, null, path);
+      saveState(key, state);
+      window.history.replaceState({ key }, null, path);
       break;
   }
 }


### PR DESCRIPTION
Location state was not saved so `getCurrentLocation()` always returned `null` for given `location.key`.

Really don't know if I get it right. :) Should only a key be saved to `window.history.state` as it is, or should whole location be saved instead? Now it is saving key to `window.history.state` and location is saved using `saveState()`.