### PR TITLE
getCurrentLocation in Memory history fix

### DIFF
--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -75,7 +75,7 @@ function createMemoryHistory(options={}) {
   function getCurrentLocation() {
     var { key, pathname, search } = entries[current];
     var state = readState(key);
-    return createLocation(key, state, pathname + search);
+    return createLocation(key, state, pathname + (search || ''));
   }
 
   function canGo(n) {


### PR DESCRIPTION
Fixes if search is undefined. `getCurrentLocation` will return `/undefined`.

It can be reproduced by calling just:

`createMemoryHistory()` where entries are set to `[/]` and then are internally transformed to `[{ pathname: '/', key: 'something' }]`.