### PR TITLE
Initial POP event has location.key defined

### DIFF
--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -4,6 +4,7 @@ import describeTransitions from './describeTransitions';
 import describePushState from './describePushState';
 import describeReplaceState from './describeReplaceState';
 import describeGo from './describeGo';
+import describeInitialLocation from './describeInitialLocation';
 
 describe('browser history', function () {
   beforeEach(function () {
@@ -11,12 +12,14 @@ describe('browser history', function () {
   });
 
   if (supportsHistory()) {
+    describeInitialLocation(createBrowserHistory);
     describeTransitions(createBrowserHistory);
     describePushState(createBrowserHistory);
     describeReplaceState(createBrowserHistory);
     describeGo(createBrowserHistory);
   } else {
     describe.skip(null, function () {
+      describeInitialLocation(createBrowserHistory);
       describeTransitions(createBrowserHistory);
       describePushState(createBrowserHistory);
       describeReplaceState(createBrowserHistory);

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -8,6 +8,7 @@ import describePushState from './describePushState';
 import describeReplaceState from './describeReplaceState';
 import describeGo from './describeGo';
 import execSteps from './execSteps';
+import describeInitialLocation from './describeInitialLocation';
 
 function describeStatePersistence(createHistory) {
   describe('when the user does not want to persist a state', function () {
@@ -115,6 +116,7 @@ describe('hash history', function () {
       window.location.hash = '';
   });
 
+  describeInitialLocation(createHashHistory);
   describeTransitions(createHashHistory);
   describePushState(createHashHistory);
   describeReplaceState(createHashHistory);

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -4,8 +4,10 @@ import describeTransitions from './describeTransitions';
 import describePushState from './describePushState';
 import describeReplaceState from './describeReplaceState';
 import describeGo from './describeGo';
+import describeInitialLocation from './describeInitialLocation';
 
 describe('memory history', function () {
+  describeInitialLocation(createMemoryHistory);
   describeTransitions(createMemoryHistory);
   describePushState(createMemoryHistory);
   describeReplaceState(createMemoryHistory);

--- a/modules/__tests__/describeInitialLocation.js
+++ b/modules/__tests__/describeInitialLocation.js
@@ -1,0 +1,60 @@
+import expect from 'expect';
+import { POP } from '../Actions';
+import createMemoryHistory from '../createMemoryHistory';
+
+function describeInitialLocation(createHistory) {
+  describe('location has key on initial pop', function() {
+    var unlisten, history;
+
+    beforeEach(function() {
+      history = createHistory();
+    });
+
+    afterEach(function() {
+      if (unlisten) unlisten();
+    });
+
+    it('replaces state if location key is missing', function(done) {
+      unlisten = history.listen(function(location) {
+        try {
+          expect(location.action).toEqual(POP);
+          expect(location.key).toNotEqual(null);
+          expect(location.state).toEqual(null);
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+
+    it('emits POP with current location key', function(done) {
+      // set initial state, this is needed because all implementations gets state from different places
+      history.pushState({ initial: 'state' }, '/');
+
+      // now create history for testing if initial POP event has location.key
+      history = createHistory();
+
+      unlisten = history.listen(function(location) {
+        try {
+          expect(location.action).toEqual(POP);
+          expect(location.key).toNotEqual(null);
+
+          // in case of memory history we can get saved state, because generated key is always unique
+          // and even if we save state to sessionStorage, we can not get it between instances of MemoryHistory
+          // because key will be not mapped to given state
+          if (createHistory !== createMemoryHistory) {
+            expect(location.state).toEqual({ initial: 'state' });
+          } else {
+            expect(location.state).toEqual(null);
+          }
+
+          done();
+        } catch (e) {
+          done(e);
+        }
+      });
+    });
+  });
+}
+
+export default describeInitialLocation;

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -1,6 +1,6 @@
 import invariant from 'invariant';
 import deepEqual from 'deep-equal';
-import { PUSH, REPLACE } from './Actions';
+import { PUSH, REPLACE, POP } from './Actions';
 import createLocation from './createLocation';
 
 function createRandomKey(length) {
@@ -28,7 +28,12 @@ function createHistory(options={}) {
   var location;
 
   function updateLocation(newLocation) {
-    location = newLocation;
+    // if previous location is unknown, we are probably replacing on initial load
+    if (!location) {
+      location = { ...newLocation, action: POP };
+    } else {
+      location = newLocation;
+    }
 
     changeListeners.forEach(function (listener) {
       listener(location);
@@ -49,7 +54,9 @@ function createHistory(options={}) {
     if (location) {
       listener(location);
     } else {
-      updateLocation(getCurrentLocation());
+      var locationReplacement = getCurrentLocation();
+      replaceState(locationReplacement.state, locationReplacement.pathname + locationReplacement.search);
+      //updateLocation(getCurrentLocation());
     }
 
     return function () {


### PR DESCRIPTION
There is an ugly hack. 

Instead of calling `updateLocation` after registering listener and locations is undefined, we are replacing a state using the `replaceState` and in the `updateLocation` we are checking if a previous location is defined. If it isn't we replace action in a new location from REPLACE to POP and store it. Otherwise we are keeping it as it is.

We need it like this, because user expects initial event to be POP action and not REPLACE.