### PR TITLE
Transition hook that returns false will cancel transition (Issue #15)

### DIFF
--- a/modules/__tests__/describeTransitions.js
+++ b/modules/__tests__/describeTransitions.js
@@ -78,6 +78,34 @@ function describeTransitions(createHistory) {
     });
   });
 
+  describe('when the transition hook cancels a transition', function () {
+    var location, history, unlisten;
+    beforeEach(function () {
+      location = null;
+
+      history = createHistory();
+
+      history.registerTransitionHook(function () {
+        return false;
+      });
+
+      unlisten = history.listen(function (loc) {
+        location = loc;
+      });
+    });
+
+    afterEach(function () {
+      if (unlisten)
+        unlisten();
+    });
+
+    it('does not update the location', function () {
+      var prevLocation = location;
+      history.pushState(null, '/home');
+      expect(prevLocation).toBe(location);
+    });
+  });
+
   describe('when the user cancels a POP transition', function () {
     it('puts the URL back');
   });

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -69,7 +69,7 @@ function createHistory(options={}) {
   function getTransitionConfirmationMessage() {
     var message = null;
 
-    for (var i = 0, len = transitionHooks.length; i < len && message === null; ++i)
+    for (var i = 0, len = transitionHooks.length; i < len && message == null; ++i)
       message = transitionHooks[i].call(this);
 
     return message;
@@ -78,7 +78,7 @@ function createHistory(options={}) {
   function confirmTransition(callback) {
     var message = getTransitionConfirmationMessage();
 
-    if (getUserConfirmation && message) {
+    if (getUserConfirmation && typeof message === 'string') {
       getUserConfirmation(message, function (ok) {
         callback(ok !== false);
       });

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -69,21 +69,21 @@ function createHistory(options={}) {
   function getTransitionConfirmationMessage() {
     var message = null;
 
-    for (var i = 0, len = transitionHooks.length; i < len && typeof message !== 'string'; ++i)
+    for (var i = 0, len = transitionHooks.length; i < len && message === null; ++i)
       message = transitionHooks[i].call(this);
 
     return message;
   }
 
   function confirmTransition(callback) {
-    var message;
+    var message = getTransitionConfirmationMessage();
 
-    if (getUserConfirmation && (message = getTransitionConfirmationMessage())) {
+    if (getUserConfirmation && message) {
       getUserConfirmation(message, function (ok) {
         callback(ok !== false);
       });
     } else {
-      callback(true);
+      callback(message !== false);
     }
   }
 


### PR DESCRIPTION
This change adds support to allow a developer to `return false` from their transition hook to cancel the transition.

Thanks,

Ryan