### PR TITLE
Add getScrollPosition to History, and scrollX/scrollY to Location

### DIFF
--- a/modules/createDOMHistory.js
+++ b/modules/createDOMHistory.js
@@ -24,13 +24,18 @@ function startBeforeUnloadListener({ getTransitionConfirmationMessage }) {
   };
 }
 
+function getScrollPosition() {
+  return { x: window.scrollX, y: window.scrollY };
+}
+
 function createDOMHistory(options) {
   var history = createHistory({
     getUserConfirmation,
     ...options,
     saveState,
     readState,
-    go
+    go,
+    getScrollPosition
   });
 
   var listenerCount = 0;

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -17,11 +17,18 @@ function locationsAreEqual(a, b) {
 
 var DefaultKeyLength = 6;
 
+function scrollPositionUnavailable() {
+  return { x: undefined, y: undefined };
+}
+
 function createHistory(options={}) {
-  var { getCurrentLocation, finishTransition, cancelTransition, go, keyLength, getUserConfirmation } = options;
+  var { getCurrentLocation, finishTransition, cancelTransition, go, keyLength, getUserConfirmation, getScrollPosition } = options;
 
   if (typeof keyLength !== 'number')
     keyLength = DefaultKeyLength;
+
+  if (!getScrollPosition)
+    getScrollPosition = scrollPositionUnavailable;
 
   var transitionHooks = [];
   var changeListeners = [];
@@ -113,14 +120,16 @@ function createHistory(options={}) {
   }
 
   function pushState(state, path) {
+    var { x, y } = getScrollPosition();
     transitionTo(
-      createLocation(path, state, PUSH, createKey())
+      createLocation(path, state, PUSH, createKey(), x, y)
     );
   }
 
   function replaceState(state, path) {
+    var { x, y } = getScrollPosition();
     transitionTo(
-      createLocation(path, state, REPLACE, createKey())
+      createLocation(path, state, REPLACE, createKey(), x, y)
     );
   }
 

--- a/modules/createLocation.js
+++ b/modules/createLocation.js
@@ -1,6 +1,6 @@
 import { POP } from './Actions';
 
-function createLocation(path='/', state=null, action=POP, key=null) {
+function createLocation(path='/', state=null, action=POP, key=null, scrollX=undefined, scrollY=undefined) {
   var index = path.indexOf('?');
 
   var pathname, search;
@@ -20,7 +20,9 @@ function createLocation(path='/', state=null, action=POP, key=null) {
     search,
     state,
     action,
-    key
+    key,
+    scrollX,
+    scrollY
   };
 }
 


### PR DESCRIPTION
I just typed up the code snippets from @mjackson and @gaearon in the comments above, and added just a little bit of error handling (there's now a fallback if `getScrollPosition` is not supplied).

I'm also looking into writing a test for this, I'm stuck because I don't know how to mock the scroll position changing in a test.

Also, I don't know if I should include the generated changes in `lib/umd/History.js` and `lib/umd/History.min.js`.

This addresses Issue #17.