### PR TITLE
Add location.current and improve cancelling POP transitions

### DIFF
--- a/modules/__tests__/Location-test.js
+++ b/modules/__tests__/Location-test.js
@@ -27,4 +27,9 @@ describe('a location', function () {
     var location = createLocation();
     expect(location.key).toBe(null);
   });
+
+  it('has -1 current by default', function() {
+    var location = createLocation();
+    expect(location.current).toBe(-1);
+  });
 });

--- a/modules/__tests__/describeGo.js
+++ b/modules/__tests__/describeGo.js
@@ -22,6 +22,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('');
             expect(location.state).toEqual(null);
             expect(location.action).toEqual(POP);
+            expect(location.current).toEqual(0);
 
             history.pushState({ the: 'state' }, '/home?the=query');
           },
@@ -30,6 +31,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('?the=query');
             expect(location.state).toEqual({ the: 'state' });
             expect(location.action).toEqual(PUSH);
+            expect(location.current).toEqual(1);
 
             history.goBack();
           },
@@ -38,6 +40,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('');
             expect(location.state).toEqual(null);
             expect(location.action).toEqual(POP);
+            expect(location.current).toEqual(0);
           }
         ];
 
@@ -53,6 +56,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('');
             expect(location.state).toEqual(null);
             expect(location.action).toEqual(POP);
+            expect(location.current).toEqual(0);
 
             history.pushState({ the: 'state' }, '/home?the=query');
           },
@@ -61,6 +65,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('?the=query');
             expect(location.state).toEqual({ the: 'state' });
             expect(location.action).toEqual(PUSH);
+            expect(location.current).toEqual(1);
 
             history.goBack();
           },
@@ -69,6 +74,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('');
             expect(location.state).toEqual(null);
             expect(location.action).toEqual(POP);
+            expect(location.current).toEqual(0);
 
             history.goForward();
           },
@@ -77,6 +83,7 @@ function describeGo(createHistory) {
             expect(location.search).toEqual('?the=query');
             expect(location.state).toEqual({ the: 'state' });
             expect(location.action).toEqual(POP);
+            expect(location.current).toEqual(1);
           }
         ];
 

--- a/modules/__tests__/describePushState.js
+++ b/modules/__tests__/describePushState.js
@@ -21,6 +21,7 @@ function describePushState(createHistory) {
           expect(location.search).toEqual('');
           expect(location.state).toEqual(null);
           expect(location.action).toEqual(POP);
+          expect(location.current).toEqual(0);
 
           history.pushState({ the: 'state' }, '/home?the=query');
         },
@@ -29,6 +30,7 @@ function describePushState(createHistory) {
           expect(location.search).toEqual('?the=query');
           expect(location.state).toEqual({ the: 'state' });
           expect(location.action).toEqual(PUSH);
+          expect(location.current).toEqual(1);
         }
       ];
 

--- a/modules/__tests__/describeReplaceState.js
+++ b/modules/__tests__/describeReplaceState.js
@@ -21,6 +21,7 @@ function describeReplaceState(createHistory) {
           expect(location.search).toEqual('');
           expect(location.state).toEqual(null);
           expect(location.action).toEqual(POP);
+          expect(location.current).toEqual(0);
 
           history.replaceState({ the: 'state' }, '/home?the=query');
         },
@@ -29,6 +30,7 @@ function describeReplaceState(createHistory) {
           expect(location.search).toEqual('?the=query');
           expect(location.state).toEqual({ the: 'state' });
           expect(location.action).toEqual(REPLACE);
+          expect(location.current).toEqual(0);
         }
       ];
 

--- a/modules/__tests__/describeSetState.js
+++ b/modules/__tests__/describeSetState.js
@@ -21,6 +21,7 @@ function describeSetState(createHistory) {
           expect(location.search).toEqual('');
           expect(location.state).toEqual(null);
           expect(location.action).toEqual(POP);
+          expect(location.current).toEqual(0);
 
           history.setState({ the: 'state' });
         },
@@ -29,6 +30,7 @@ function describeSetState(createHistory) {
           expect(location.search).toEqual('');
           expect(location.state).toEqual({ the: 'state' });
           expect(location.action).toEqual(POP);
+          expect(location.current).toEqual(0);
         }
       ];
 

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -24,7 +24,10 @@ function createBrowserHistory(options) {
   var isSupported = supportsHistory();
 
   function getCurrentLocation(historyState) {
-    historyState = historyState || window.history.state || {};
+    if (typeof historyState === 'undefined')
+      historyState = window.history.state;
+
+    historyState = historyState || {};
 
     var path = getWindowPath();
     var { key } = historyState;

--- a/modules/createLocation.js
+++ b/modules/createLocation.js
@@ -1,6 +1,6 @@
 import { POP } from './Actions';
 
-function createLocation(path='/', state=null, action=POP, key=null) {
+function createLocation(path='/', state=null, action=POP, key=null, current=-1) {
   var index = path.indexOf('?');
 
   var pathname, search;
@@ -20,7 +20,8 @@ function createLocation(path='/', state=null, action=POP, key=null) {
     search,
     state,
     action,
-    key
+    key,
+    current
   };
 }
 


### PR DESCRIPTION
Builds upon `allKeys` from https://github.com/rackt/history/commit/96d3b2c33590e6359c3f1393946f223bd7325122 to provide `location.current`. Also fixes two things:

1. key from initial location wasn't put into `allKeys`
2. `allKeys` wasn't modified correctly for push and replace, not taking the current position into account (e.g. push should remove all keys that come after the current one)

Possible future work:

* persist keys in `sessionStorage` so it works after refresh. This would require building multiple `allKeys` lists to support multiple browsing sessions
* figure out edge cases related to using hash navigation with BrowserHistory, and try to fix or document them
