### PR TITLE
Improve cancelling POP transitions

### DIFF
--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -29,13 +29,25 @@ function createHistory(options={}) {
 
   var allKeys = [];
 
+  function getCurrent() {
+    if (pendingLocation && pendingLocation.action === POP) {
+      return allKeys.indexOf(pendingLocation.key);
+    } else if (location) {
+      return allKeys.indexOf(location.key);
+    } else {
+      return -1;
+    }
+  }
+
   function updateLocation(newLocation) {
+    var current = getCurrent();
+
     location = newLocation;
 
     if (location.action === PUSH) {
-      allKeys.push(location.key);
+      allKeys = [...allKeys.slice(0, current + 1), location.key];
     } else if (location.action === REPLACE) {
-      allKeys[allKeys.length - 1] = location.key;
+      allKeys[current] = location.key;
     }
 
     changeListeners.forEach(function (listener) {
@@ -57,7 +69,9 @@ function createHistory(options={}) {
     if (location) {
       listener(location);
     } else {
-      updateLocation(getCurrentLocation());
+      var location = getCurrentLocation();
+      allKeys = [location.key];
+      updateLocation(location);
     }
 
     return function () {


### PR DESCRIPTION
Follow-up of #28.

Fixes:

1. key from initial location wasn't put into `allKeys`
2. `allKeys` wasn't modified correctly for push and replace, not taking the current position into account (e.g. push should remove all keys that come after the current one)