### PR TITLE
Convert enableQueries to higher-order function (like a decorator)

### DIFF
--- a/modules/__tests__/describeQueries.js
+++ b/modules/__tests__/describeQueries.js
@@ -11,7 +11,7 @@ function describeQueries(createHistory) {
   describe('query serialization', function () {
     var history, unlisten;
     beforeEach(function () {
-      history = enableQueries(createHistory());
+      history = enableQueries(createHistory)();
     });
 
     afterEach(function () {

--- a/modules/enableQueries.js
+++ b/modules/enableQueries.js
@@ -8,50 +8,53 @@ function defaultParseQueryString(queryString) {
   return qs.parse(queryString);
 }
 
-function enableQueries(history, options={}) {
-  var { stringifyQuery, parseQueryString } = options;
+function enableQueries(createHistory, options={}) {
+  return (baseOptions) => {
+    var history = createHistory(baseOptions);
+    var { stringifyQuery, parseQueryString } = options;
 
-  if (typeof stringifyQuery !== 'function')
-    stringifyQuery = defaultStringifyQuery;
+    if (typeof stringifyQuery !== 'function')
+      stringifyQuery = defaultStringifyQuery;
 
-  if (typeof parseQueryString !== 'function')
-    parseQueryString = defaultParseQueryString;
+    if (typeof parseQueryString !== 'function')
+      parseQueryString = defaultParseQueryString;
 
-  function listen(listener) {
-    return history.listen(function (location) {
-      if (!location.query)
-        location.query = location.search ? parseQueryString(location.search.substring(1)) : {};
+    function listen(listener) {
+      return history.listen(function (location) {
+        if (!location.query)
+          location.query = location.search ? parseQueryString(location.search.substring(1)) : {};
 
-      listener(location);
-    });
-  }
+        listener(location);
+      });
+    }
 
-  function createPath(pathname, query) {
-    var queryString;
-    if (query == null || (queryString = stringifyQuery(query)) === '')
-      return pathname;
+    function createPath(pathname, query) {
+      var queryString;
+      if (query == null || (queryString = stringifyQuery(query)) === '')
+        return pathname;
 
-    return pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString;
-  }
+      return pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString;
+    }
 
-  function pushState(state, pathname, query) {
-    return history.pushState(state, createPath(pathname, query));
-  }
+    function pushState(state, pathname, query) {
+      return history.pushState(state, createPath(pathname, query));
+    }
 
-  function replaceState(state, pathname, query) {
-    return history.replaceState(state, createPath(pathname, query));
-  }
+    function replaceState(state, pathname, query) {
+      return history.replaceState(state, createPath(pathname, query));
+    }
 
-  function createHref(pathname, query) {
-    return history.createHref(createPath(pathname, query));
-  }
+    function createHref(pathname, query) {
+      return history.createHref(createPath(pathname, query));
+    }
 
-  return {
-    ...history,
-    listen,
-    pushState,
-    replaceState,
-    createHref
+    return {
+      ...history,
+      listen,
+      pushState,
+      replaceState,
+      createHref
+    };
   };
 }
 


### PR DESCRIPTION
Extensions like `enableQueries` are more powerful if they operate on a function (`createHistory`) rather than the thing it returns (`history`). The reason in a nutshell is that it allows the extension to intercept/modify both the input and output of the function. For example, this is how decorators work. It's also how store enhancers, like `applyMiddleware()` and `devtools()`, work in Redux.

For simple extensions like enableQueries, it doesn't end up making a huge difference, but for future extensions it may. Better to establish the convention now rather than later :)

(Because of indentation, this looks like a bigger PR than it actually is. The key lines that have changed are 11-13 of `enableQueries.js`.)