### PR TITLE
Expose createPath

### DIFF
--- a/modules/__tests__/describeQueries.js
+++ b/modules/__tests__/describeQueries.js
@@ -76,6 +76,14 @@ function describeQueries(createHistory) {
       });
     });
 
+    describe('in createPath', function () {
+      it('works', function () {
+        expect(
+          history.createPath('/the/path', { the: 'query' })
+        ).toEqual('/the/path?STRINGIFY_QUERY');
+      });
+    });
+
     describe('in createHref', function () {
       it('works', function () {
         expect(

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -176,8 +176,12 @@ function createHistory(options={}) {
     return createRandomKey(keyLength);
   }
 
-  function createHref(path) {
+  function createPath(path) {
     return path;
+  }
+
+  function createHref(path) {
+    return createPath(path);
   }
 
   return {
@@ -193,6 +197,7 @@ function createHistory(options={}) {
     goBack,
     goForward,
     createKey,
+    createPath,
     createHref
   };
 }

--- a/modules/enableQueries.js
+++ b/modules/enableQueries.js
@@ -34,7 +34,9 @@ function enableQueries(createHistory) {
       if (query == null || (queryString = stringifyQuery(query)) === '')
         return pathname;
 
-      return pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString;
+      return history.createPath(
+        pathname + (pathname.indexOf('?') === -1 ? '?' : '&') + queryString
+      );
     }
 
     function pushState(state, pathname, query) {
@@ -54,6 +56,7 @@ function enableQueries(createHistory) {
       listen,
       pushState,
       replaceState,
+      createPath,
       createHref
     };
   };


### PR DESCRIPTION
This makes `createPath()` part of the standard history interface. Previously it was only added by `enableQueries()`, but I think it's useful for any consumer to be able to call `createPath()`, regardless of whether queries are enabled or not.