### PR TITLE
Fix options being undefined exception

### DIFF
--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -12,7 +12,7 @@ function useQueries(createHistory) {
   return (options) => {
     var history = createHistory(options);
 
-    var { stringifyQuery, parseQueryString } = options;
+    var { stringifyQuery, parseQueryString } = options || {};
 
     if (typeof stringifyQuery !== 'function')
       stringifyQuery = defaultStringifyQuery;


### PR DESCRIPTION
Error: Cannot read property 'stringifyQuery' of undefined