### PR TITLE
Fix MemoryHistory "top of stack" check

### DIFF
--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -53,6 +53,13 @@ describe('memory history', function () {
       expect(function () {
         history.goForward()
       }).toThrow(/Cannot go\(\d+\) there is not enough history/)
+
+      history.goBack()
+      history.pushState({ id: 6 }, '/6')
+
+      expect(function () {
+        history.goForward()
+      }).toThrow(/Cannot go\(\d+\) there is not enough history/)
     })
   })
 })

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -117,7 +117,7 @@ function createMemoryHistory(options={}) {
 
         // if we are not on the top of stack
         // remove rest and push new
-        if (current < (entries.length - 1)) {
+        if (current < entries.length) {
           entries.splice(current)
         }
 


### PR DESCRIPTION
`current` has only been incremented at the time of the check.