### PR TITLE
Don't create a new history entry when transitioning to the current path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## HEAD
 
 - Fail gracefully when Safari security settings prevent access to window.sessionStorage
+- Pushing the currently active path will result in a replace to not create additional browser history entries (see [#43])
+
+[#43]: https://github.com/rackt/history/pull/43
 
 ## [v1.13.0]
 > Oct 28, 2015

--- a/modules/__tests__/describePushState.js
+++ b/modules/__tests__/describePushState.js
@@ -1,6 +1,6 @@
 /*eslint-env mocha */
 import expect from 'expect'
-import { PUSH, POP } from '../Actions'
+import { PUSH, POP, REPLACE } from '../Actions'
 import execSteps from './execSteps'
 
 function describePushState(createHistory) {
@@ -30,6 +30,35 @@ function describePushState(createHistory) {
           expect(location.search).toEqual('?the=query')
           expect(location.state).toEqual({ the: 'state' })
           expect(location.action).toEqual(PUSH)
+        }
+      ]
+
+      unlisten = history.listen(execSteps(steps, done))
+    })
+
+    it('becomes a REPLACE if path is unchanged', function (done) {
+      let steps = [
+        function (location) {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(POP)
+
+          history.pushState({ the: 'state' }, '/home?the=query')
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual({ the: 'state' })
+          expect(location.action).toEqual(PUSH)
+
+          history.pushState({ different: 'state' }, '/home?the=query')
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual({ different: 'state' })
+          expect(location.action).toEqual(REPLACE)
         }
       ]
 

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -95,28 +95,27 @@ function createHashHistory(options={}) {
 
     let path = (basename || '') + pathname + search
 
-    if (queryKey)
+    if (queryKey) {
       path = addQueryStringValueToPath(path, queryKey, key)
-
-    if (path === getHashPath()) {
-      warning(
-        false,
-        'You cannot %s the same path using hash history',
-        action
-      )
+      saveState(key, state)
     } else {
-      if (queryKey) {
-        saveState(key, state)
-      } else {
-        // Drop key and state.
-        location.key = location.state = null
-      }
+      // Drop key and state.
+      location.key = location.state = null
+    }
 
-      if (action === PUSH) {
+    let currentHash = getHashPath()
+
+    if (action === PUSH) {
+      if (currentHash !== path) {
         window.location.hash = path
-      } else { // REPLACE
-        replaceHashPath(path)
+      } else {
+        warning(
+          false,
+          'You cannot PUSH the same path using hash history'
+        )
       }
+    } else if (currentHash !== path) { // REPLACE
+      replaceHashPath(path)
     }
   }
 

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -114,6 +114,16 @@ function createHistory(options={}) {
         return // Transition was interrupted.
 
       if (ok) {
+        // treat PUSH to current path like REPLACE to be consistent with browsers
+        if (nextLocation.action === PUSH) {
+          let { pathname, search } = getCurrentLocation()
+          let currentPath = pathname + search
+          let path = nextLocation.pathname + nextLocation.search
+
+          if (currentPath === path)
+            nextLocation.action = REPLACE
+        }
+
         if (finishTransition(nextLocation) !== false)
           updateLocation(nextLocation)
       } else if (location && nextLocation.action === POP) {


### PR DESCRIPTION
This PR normalizes the behavior of all histories to not create a new history entry when pushing the path that's already active. Like browsers do with static content.

Currently, all histories create new entries, except `HashHistory` without `queryKey` since it's unable to do so. Instead, it'll print a [warning](https://github.com/rackt/history/blob/master/modules/createHashHistory.js#L103) which doesn't seem right considering it's a common scenario.

I implemented it in the history's `finishTransition` methods to treat these cases like a `REPLACE`. `location.action` will still be `PUSH` though. Alternatively, I think this could be implemented in the base history to change `location.action` to `REPLACE`. That's what I was doing in an older [PR](https://github.com/rackt/react-router/blob/836032130c4cffa7b6d97b892043f1d7ac2cd1f3/modules/History.js#L171).

Also related: https://github.com/rackt/react-router/pull/1031
