### PR TITLE
Check that history is supported before trying to replaceState

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -35,7 +35,9 @@ function createBrowserHistory(options) {
     } else {
       state = null
       key = history.createKey()
-      window.history.replaceState({ ...historyState, key }, null, path)
+      if (isSupported) {
+        window.history.replaceState({ ...historyState, key }, null, path)
+      }
     }
 
     return createLocation(path, state, undefined, key)


### PR DESCRIPTION
All other calls to replaceState et. al. does a check of isSupported to make sure it will work, except this one. I believe is the correct solution, at least it solves my IE problems!