### PR TITLE
don't strip the hash off of the window path

### DIFF
--- a/modules/DOMUtils.js
+++ b/modules/DOMUtils.js
@@ -27,7 +27,7 @@ export function replaceHashPath(path) {
 }
 
 export function getWindowPath() {
-  return window.location.pathname + window.location.search
+  return window.location.pathname + window.location.search + window.location.hash
 }
 
 export function go(n) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/rackt/history/issues",
   "scripts": {
-    "build": "babel ./modules --babelrc .babelrc -d lib --ignore '__tests__'",
+    "build": "babel ./modules --stage 0 --loose -d lib --ignore '__tests__'",
     "build-umd": "NODE_ENV=production webpack modules/index.js umd/History.js",
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/History.min.js",
     "start": "webpack-dev-server -d --content-base ./ --history-api-fallback --inline modules/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/rackt/history/issues",
   "scripts": {
-    "build": "babel ./modules -d lib --ignore '__tests__'",
+    "build": "babel ./modules --babelrc ./.babelrc -d lib --ignore '__tests__'",
     "build-umd": "NODE_ENV=production webpack modules/index.js umd/History.js",
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/History.min.js",
     "start": "webpack-dev-server -d --content-base ./ --history-api-fallback --inline modules/index.js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/rackt/history/issues",
   "scripts": {
-    "build": "babel ./modules --babelrc ./.babelrc -d lib --ignore '__tests__'",
+    "build": "babel ./modules --babelrc .babelrc -d lib --ignore '__tests__'",
     "build-umd": "NODE_ENV=production webpack modules/index.js umd/History.js",
     "build-min": "NODE_ENV=production webpack -p modules/index.js umd/History.min.js",
     "start": "webpack-dev-server -d --content-base ./ --history-api-fallback --inline modules/index.js",


### PR DESCRIPTION
Without this change, when using `createHistory` or `createBrowserHistory`, the `window.location.hash` gets stripped off of the location, never to be recovered, breaking in-page navigation when using react-router.