### PR TITLE
Make createLocation an instance method

### DIFF
--- a/docs/Location.md
+++ b/docs/Location.md
@@ -14,10 +14,8 @@ Support for query string parsing is provided using the [`useQueries` module](Que
 
 ### Programmatic Creation
 
-You may occasionally need to create a `location` object, either for testing or when using `history` in a stateless environment (like a server). `history` exposes the `createLocation` API for this purpose.
+You may occasionally need to create a `location` object, either for testing or when using `history` in a stateless environment (like a server). `history` objects have a `createLocation` method for this purpose.
 
 ```js
-import createLocation from 'history/lib/createLocation'
-
-let location = createLocation('/a/path?a=query', { the: 'state' })
+let location = history.createLocation('/a/path?a=query', { the: 'state' })
 ```

--- a/modules/__tests__/Location-test.js
+++ b/modules/__tests__/Location-test.js
@@ -1,9 +1,14 @@
 /*eslint-env mocha */
 import expect from 'expect'
-import createLocation from '../createLocation'
+import createHistory from '../createHistory'
 import { POP } from '../Actions'
 
 describe('a location', function () {
+  let createLocation
+  beforeEach(function () {
+    createLocation = createHistory().createLocation
+  })
+
   it('knows its pathname', function () {
     let location = createLocation('/home?the=query')
     expect(location.pathname).toEqual('/home')

--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -4,7 +4,6 @@ import { canUseDOM } from './ExecutionEnvironment'
 import { addEventListener, removeEventListener, getWindowPath, supportsHistory } from './DOMUtils'
 import { saveState, readState } from './DOMStateStorage'
 import createDOMHistory from './createDOMHistory'
-import createLocation from './createLocation'
 
 /**
  * Creates and returns a history object that uses HTML5's history API
@@ -40,7 +39,7 @@ function createBrowserHistory(options) {
         window.history.replaceState({ ...historyState, key }, null, path)
     }
 
-    return createLocation(path, state, undefined, key)
+    return history.createLocation(path, state, undefined, key)
   }
 
   function startPopStateListener({ transitionTo }) {

--- a/modules/createHashHistory.js
+++ b/modules/createHashHistory.js
@@ -5,7 +5,6 @@ import { canUseDOM } from './ExecutionEnvironment'
 import { addEventListener, removeEventListener, getHashPath, replaceHashPath, supportsGoWithoutReloadUsingHash } from './DOMUtils'
 import { saveState, readState } from './DOMStateStorage'
 import createDOMHistory from './createDOMHistory'
-import createLocation from './createLocation'
 
 function isAbsolutePath(path) {
   return typeof path === 'string' && path.charAt(0) === '/'
@@ -65,7 +64,7 @@ function createHashHistory(options={}) {
       }
     }
 
-    return createLocation(path, state, undefined, key)
+    return history.createLocation(path, state, undefined, key)
   }
 
   function startHashChangeListener({ transitionTo }) {

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -1,12 +1,59 @@
+import warning from 'warning'
 import deepEqual from 'deep-equal'
 import { loopAsync } from './AsyncUtils'
 import { PUSH, REPLACE, POP } from './Actions'
-import createLocation from './createLocation'
 import runTransitionHook from './runTransitionHook'
 import deprecate from './deprecate'
 
 function createRandomKey(length) {
   return Math.random().toString(36).substr(2, length)
+}
+
+function extractPath(string) {
+  let match = string.match(/https?:\/\/[^\/]*/)
+
+  if (match == null)
+    return string
+
+  warning(
+    false,
+    'Location path must be pathname + query string only, not a fully qualified URL like "%s"',
+    string
+  )
+
+  return string.substring(match[0].length)
+}
+
+function createLocation(path='/', state=null, action=POP, key=null) {
+  path = extractPath(path)
+
+  let pathname = path
+  let search = ''
+  let hash = ''
+
+  let hashIndex = pathname.indexOf('#')
+  if (hashIndex !== -1) {
+    hash = pathname.substring(hashIndex)
+    pathname = pathname.substring(0, hashIndex)
+  }
+
+  let searchIndex = pathname.indexOf('?')
+  if (searchIndex !== -1) {
+    search = pathname.substring(searchIndex)
+    pathname = pathname.substring(0, searchIndex)
+  }
+
+  if (pathname === '')
+    pathname = '/'
+
+  return {
+    pathname,
+    search,
+    hash,
+    state,
+    action,
+    key
+  }
 }
 
 function locationsAreEqual(a, b) {
@@ -196,6 +243,7 @@ function createHistory(options={}) {
     createKey,
     createPath,
     createHref,
+    createLocation,
 
     registerTransitionHook: deprecate(
       registerTransitionHook,

--- a/modules/createLocation.js
+++ b/modules/createLocation.js
@@ -1,4 +1,5 @@
 import warning from 'warning'
+import deprecate from './deprecate'
 import { POP } from './Actions'
 
 function extractPath(string) {
@@ -48,4 +49,7 @@ function createLocation(path='/', state=null, action=POP, key=null) {
   }
 }
 
-export default createLocation
+export default deprecate(
+  createLocation,
+  'createLocation is deprecated; use history.createLocation instead'
+)

--- a/modules/createMemoryHistory.js
+++ b/modules/createMemoryHistory.js
@@ -1,6 +1,5 @@
 import invariant from 'invariant'
 import { PUSH, REPLACE, POP } from './Actions'
-import createLocation from './createLocation'
 import createHistory from './createHistory'
 
 function createStateStorage(entries) {
@@ -85,7 +84,7 @@ function createMemoryHistory(options={}) {
       entry.key = key
     }
 
-    return createLocation(path, state, undefined, key)
+    return history.createLocation(path, state, undefined, key)
   }
 
   function canGo(n) {

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,7 +1,6 @@
 export createHistory from './createBrowserHistory'
 export createHashHistory from './createHashHistory'
 export createMemoryHistory from './createMemoryHistory'
-export createLocation from './createLocation'
 
 export useBasename from './useBasename'
 export useBeforeUnload from './useBeforeUnload'
@@ -10,5 +9,6 @@ export useQueries from './useQueries'
 export Actions from './Actions'
 
 // deprecated
+export createLocation from './createLocation'
 export enableBeforeUnload from './enableBeforeUnload'
 export enableQueries from './enableQueries'

--- a/modules/useBasename.js
+++ b/modules/useBasename.js
@@ -5,7 +5,7 @@ function useBasename(createHistory) {
     let { basename, ...historyOptions } = options
     let history = createHistory(historyOptions)
 
-    function stripBasename(location) {
+    function addBasename(location) {
       if (basename && location.basename == null) {
         if (location.pathname.indexOf(basename) === 0) {
           location.pathname = location.pathname.substring(basename.length)
@@ -21,38 +21,42 @@ function useBasename(createHistory) {
       return location
     }
 
-    function addBasename(path) {
+    function prependBasename(path) {
       return basename ? basename + path : path
     }
 
     // Override all read methods with basename-aware versions.
     function listenBefore(hook) {
       return history.listenBefore(function (location, callback) {
-        runTransitionHook(hook, stripBasename(location), callback)
+        runTransitionHook(hook, addBasename(location), callback)
       })
     }
 
     function listen(listener) {
       return history.listen(function (location) {
-        listener(stripBasename(location))
+        listener(addBasename(location))
       })
     }
 
     // Override all write methods with basename-aware versions.
     function pushState(state, path) {
-      history.pushState(state, addBasename(path))
+      history.pushState(state, prependBasename(path))
     }
 
     function replaceState(state, path) {
-      history.replaceState(state, addBasename(path))
+      history.replaceState(state, prependBasename(path))
     }
 
     function createPath(path) {
-      return history.createPath(addBasename(path))
+      return history.createPath(prependBasename(path))
     }
 
     function createHref(path) {
-      return history.createHref(addBasename(path))
+      return history.createHref(prependBasename(path))
+    }
+
+    function createLocation() {
+      return addBasename(history.createLocation.apply(history, arguments))
     }
 
     return {
@@ -62,7 +66,8 @@ function useBasename(createHistory) {
       pushState,
       replaceState,
       createPath,
-      createHref
+      createHref,
+      createLocation
     }
   }
 }

--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -69,6 +69,10 @@ function useQueries(createHistory) {
       return history.createHref(appendQuery(pathname, query))
     }
 
+    function createLocation() {
+      return addQuery(history.createLocation.apply(history, arguments))
+    }
+
     return {
       ...history,
       listenBefore,
@@ -76,7 +80,8 @@ function useQueries(createHistory) {
       pushState,
       replaceState,
       createPath,
-      createHref
+      createHref,
+      createLocation
     }
   }
 }


### PR DESCRIPTION
A single, global createLocation method cannot be aware of history enhancers like `useQueries`. So users need to manually modify location objects when creating them programmatically instead of getting them in a `listen` callback.

This commit makes `createLocation` an instance method of history objects and deprecates the `createLocation` method on the top-level exports.