### PR TITLE
Clarify createLocation deprecation message.

### DIFF
--- a/docs/Location.md
+++ b/docs/Location.md
@@ -17,5 +17,7 @@ Support for query string parsing is provided using the [`useQueries` module](Que
 You may occasionally need to create a `location` object, either for testing or when using `history` in a stateless environment (like a server). `history` objects have a `createLocation` method for this purpose.
 
 ```js
+import { createHistory } from 'history'
+let history = createHistory()
 let location = history.createLocation('/a/path?a=query', { the: 'state' })
 ```

--- a/modules/createLocation.js
+++ b/modules/createLocation.js
@@ -51,5 +51,5 @@ function createLocation(path='/', state=null, action=POP, key=null) {
 
 export default deprecate(
   createLocation,
-  'createLocation is deprecated; use history.createLocation instead'
+  'Calling createLocation statically is deprecated; instead call the history.createLocation method - see docs/Location.md'
 )

--- a/modules/deprecate.js
+++ b/modules/deprecate.js
@@ -2,7 +2,7 @@ import warning from 'warning'
 
 function deprecate(fn, message) {
   return function () {
-    warning(false, message)
+    warning(false, '[history] ' + message)
     return fn.apply(this, arguments)
   }
 }


### PR DESCRIPTION
Observing new messages in your server log can be bewildering.
You do not know where the text is coming from, and only `grep` can save you.
Once you've found it, what does it mean? Perhaps, you've only copy/pasted
reference code from some popular module's docs.

Attempt to provide context as to what is complaining, and why it's complaining.