### PR TITLE
Proposal: Allow .listen(cb, false) to not be called immediately

### DIFF
--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -65,10 +65,10 @@ function createHistory(options={}) {
     })
   }
 
-  function listen(listener) {
+  function listen(listener, callImmediate = true) {
     changeListeners.push(listener)
 
-    if (location) {
+    if (location && callImmediate) {
       listener(location)
     } else {
       let location = getCurrentLocation()


### PR DESCRIPTION
This is a proposal. If you're onboard with this API change I'll gladly do all the leg work to get everything working / tested / documented etc...

**Here's my use case**:
I am opening a modal. If I use back/forward buttons I want the modal to close.

For this use case, the callback being called immediately causes problems.

I want to unbind when:
- modal closes
- url navigates (listenToOnce essentially)

**What I currently have to do**:
```js
let unlistenToHistory;

{
	onModalOpen: function() {
		unlistenToHistory = history.listen((location) => {
			if (unlistenToHistory){
				// unbind the urlChange listener
				unlistenToHistory();
				this.closeModal();
			}
		});
	},
	onModalClose: function() {
		if (unlistenToHistory) {
			unlistenToHistory(); // unbind the urlChange listener
			unlistenToHistory = undefined;
		}
	},
}
```

**What I'd love, is to be able to do this**:
```js
let unlistenToHistory;

{
	onModalOpen: function() {
		unlistenToHistory = history.listen((location) => {
			unlistenToHistory(); // this will be set, since cb isn't called immediately
			this.closeModal();
		}, false);
	},
	onModalClose: function() {
		if (unlistenToHistory) {
			unlistenToHistory(); // unbind the urlChange listener
			unlistenToHistory = undefined;
		}
	},
}
```

TODO:
- [ ] Add tests
- [ ] Update docs
- [ ] Ensure all `listen()` instances behave the same...