### PR TITLE
enforce 2 space indentation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,9 @@
     "array-bracket-spacing": [2, "always"],
     "comma-dangle": [2, "never"],
     "eol-last": 2,
+    "indent": [2, 2, {
+      "SwitchCase": 1
+    }],
     "no-multiple-empty-lines": 2,
     "object-curly-spacing": [2, "always"],
     "quotes": [2, "single", "avoid-escape"],


### PR DESCRIPTION
based on @taion's [observation that 3 space indentation wasn't detected](https://github.com/rackt/history/pull/100#discussion_r41945748). might make sense to factor out the eslint config into a rackt repo, then have all repos extend it rather than updating each one. thoughts? 