### PR TITLE
allow histories to cancel location updates

### DIFF
--- a/modules/createBrowserHistory.js
+++ b/modules/createBrowserHistory.js
@@ -76,15 +76,19 @@ function createBrowserHistory(options) {
       if (isSupported) {
         window.history.pushState(historyState, null, path)
       } else {
-        // Use a full-page reload to preserve the URL.
+        // Use a full-page reload to preserve the URL, and return
+        // false to stop any location updates.
         window.location.href = path
+        return false
       }
     } else { // REPLACE
       if (isSupported) {
         window.history.replaceState(historyState, null, path)
       } else {
-        // Use a full-page reload to preserve the URL.
+        // Use a full-page reload to preserve the URL, and return
+        // false to stop any location updates.
         window.location.replace(path)
+        return false
       }
     }
   }

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -114,8 +114,9 @@ function createHistory(options={}) {
         return // Transition was interrupted.
 
       if (ok) {
-        finishTransition(nextLocation)
-        updateLocation(nextLocation)
+        if(finishTransition(nextLocation) !== false) {
+          updateLocation(nextLocation)
+        }
       } else if (location && nextLocation.action === POP) {
         let prevIndex = allKeys.indexOf(location.key)
         let nextIndex = allKeys.indexOf(nextLocation.key)


### PR DESCRIPTION
This is spawned from #100. Right now if a browser doesn't support `pushState` (or the user is forcing full refreshes), the router still immediately calls listeners, meaning react-router still tries to immediately render the new location within the same page, even though a full reload has been triggered. This causes glitches when navigating: the page changes (most likely to an invalid state) and then a second later the whole thing reloads.

This allows `finishTransition` in `createBrowserHistory` to return `false` when reloading the whole page to cancel location updates, so nothing happens.