### PR TITLE
Fix saveState to handle QuotaExceededError

### DIFF
--- a/modules/DOMStateStorage.js
+++ b/modules/DOMStateStorage.js
@@ -8,18 +8,33 @@ function createKey(key) {
   return KeyPrefix + key
 }
 
+function isHistoryKey(key) {
+  return key.indexOf(KeyPrefix) === 0
+}
+
 export function saveState(key, state) {
   try {
     window.sessionStorage.setItem(createKey(key), JSON.stringify(state))
   } catch (error) {
-    if (error.name === QuotaExceededError || window.sessionStorage.length === 0) {
-      // Probably in Safari "private mode" where sessionStorage quota is 0. #42
-      warning(
-        false,
-        '[history] Unable to save state; sessionStorage is not available in Safari private mode'
-      )
+    if (error.name === QuotaExceededError) {
+      if (window.sessionStorage.length === 0) {
+        // Probably in Safari "private mode" where sessionStorage quota is 0. #42
+        warning(
+          false,
+          '[history] Unable to save state; sessionStorage is not available in Safari private mode'
+        )
 
-      return
+        return
+      }
+
+      // Reached quota, remove first (oldest) item in storage
+      for (const storedKey in window.sessionStorage) {
+        if (isHistoryKey(storedKey)) {
+          window.sessionStorage.removeItem(storedKey)
+
+          return saveState(key, state)
+        }
+      }
     }
 
     throw error

--- a/modules/__tests__/DOMStateStorage-test.js
+++ b/modules/__tests__/DOMStateStorage-test.js
@@ -1,0 +1,44 @@
+/*eslint-env mocha */
+import expect from 'expect'
+import { saveState, readState } from '../DOMStateStorage'
+
+function patchSetItem() {
+  const _setItem = window.sessionStorage.setItem
+  window.sessionStorage.setItem = function () {
+    window.sessionStorage.setItem = _setItem
+    let error = new Error()
+    error.name = 'QuotaExceededError'
+    throw error
+  }
+}
+
+describe('saving state to sessionStorage after reaching quota', function () {
+  beforeEach(function () {
+    window.sessionStorage.clear()
+  })
+
+  it('removes the first history item from sessionStorage', function () {
+    window.sessionStorage.setItem('@@History/1', JSON.stringify({ key: '1' }))
+    window.sessionStorage.setItem('@@History/2', JSON.stringify({ key: '2' }))
+    patchSetItem()
+    saveState('3', { key: '3' })
+    expect(window.sessionStorage.getItem('@@History/1')).toEqual(undefined)
+    expect(readState('2')).toEqual({ key: '2' })
+  })
+
+  it('does not remove non history items from sessionStorage', function () {
+    window.sessionStorage.setItem('someKey', 'someValue')
+    window.sessionStorage.setItem('@@History/1', JSON.stringify({ key: '1' }))
+    patchSetItem()
+    saveState('2', { key: '2' })
+    expect(window.sessionStorage.getItem('someKey')).toEqual('someValue')
+    expect(window.sessionStorage.getItem('@@History/1')).toEqual(undefined)
+  })
+
+  it('saves passed state to sessionStorage', function () {
+    window.sessionStorage.setItem('@@History/1', JSON.stringify({ key: '1' }))
+    patchSetItem()
+    saveState('2', { key: '2' })
+    expect(readState('2')).toEqual({ key: '2' })
+  })
+})


### PR DESCRIPTION
This patch:

• Fixes https://github.com/rackt/history/issues/84 by removing the oldest state in sessionStorage before attempting to saveState again. 
