### PR TITLE
Look for protocol/host at the start of paths only.

### DIFF
--- a/modules/__tests__/Location-test.js
+++ b/modules/__tests__/Location-test.js
@@ -20,6 +20,17 @@ describe('a location', function () {
     expect(location.hash).toEqual('#the-hash')
   })
 
+  it('compensates if the location is fully qualified', function () {
+    let location = createLocation('https://example.com/home')
+    expect(location.pathname).toEqual('/home')
+  })
+
+  it('does not strip URL-like strings in the query', function () {
+    let location = createLocation('/home?redirect=https://example.com/')
+    expect(location.pathname).toEqual('/home')
+    expect(location.search).toEqual('?redirect=https://example.com/')
+  })
+
   it('has null state by default', function () {
     let location = createLocation()
     expect(location.state).toBe(null)

--- a/modules/parsePath.js
+++ b/modules/parsePath.js
@@ -1,7 +1,7 @@
 import warning from 'warning'
 
 function extractPath(string) {
-  const match = string.match(/https?:\/\/[^\/]*/)
+  const match = string.match(/^https?:\/\/[^\/]*/)
 
   if (match == null)
     return string


### PR DESCRIPTION
extractPath erroneously detected a fully-qualified URL when a URL-like string
was in the path (i.e. in the query).