### PR TITLE
Use a shared eslint config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,27 +1,3 @@
 {
-  "extends": "eslint:recommended",
-  "ecmaFeatures": {
-    "modules": true
-  },
-  "env": {
-    "browser": true,
-    "node": true,
-    "es6": true
-  },
-  "parser": "babel-eslint",
-  "rules": {
-    "array-bracket-spacing": [2, "always"],
-    "comma-dangle": [2, "never"],
-    "eol-last": 2,
-    "indent": [2, 2, {
-      "SwitchCase": 1
-    }],
-    "no-multiple-empty-lines": 2,
-    "object-curly-spacing": [2, "always"],
-    "quotes": [2, "single", "avoid-escape"],
-    "semi": [2, "never"],
-    "strict": 0,
-    "space-before-blocks": [2, "always"],
-    "space-before-function-paren": [2, {"anonymous":"always","named":"never"}]
-  }
+  "extends": "rackt"
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-eslint": "^3.1.23",
     "babel-loader": "^5.0.0",
     "eslint": "1.4.1",
+    "eslint-config-rackt": "1.0.0",
     "eslint-plugin-react": "3.3.2",
     "expect": "^1.12.0",
     "gzip-size": "^3.0.0",


### PR DESCRIPTION
### Goal
Shared eslint config for all rackt repos. That eslint config now lives here: https://github.com/rackt/eslint-config-rackt

### Todo
I suspect there are subtle differences between repos, so migrating other repos to the shared config will probably require additional PRs. I'll try to take that on so I don't introduce something that goes unused (assuming there's any interest in this).