### PR TITLE
Adds `history.push()` and `history.replace()` methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules
 lib
 umd

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -33,6 +33,11 @@ You can also use a `history` object to programmatically change the current `loca
 - `goBack()`
 - `goForward()`
 
+There are also two handy methods that allow you not to specify `state` object during transitions:
+
+- `push(path[, state])`
+- `replace(path[, state])`
+
 The [`path`](Glossary.md#path) argument to `pushState` and `replaceState` represents a complete URL path, including the [query string](Glossary.md#querystring). The [`state`](Glossary.md#locationstate) argument should be a JSON-serializable object.
 
 ```js
@@ -41,6 +46,9 @@ history.pushState({ some: 'state' }, '/home')
 
 // Replace the current entry on the history stack.
 history.replaceState({ some: 'other state' }, '/profile')
+
+// Push a new history entry, omitting `state` object (it will be set to `null`)
+history.push('/about')
 
 // Go back to the previous history entry. The following
 // two lines are synonymous.

--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -40,6 +40,8 @@ A *createHistory enhancer* (or simply a "history enhancer") is a function that a
       transitionTo(location: Location) => void;
       pushState(state: LocationState, path: Path) => void;
       replaceState(state: LocationState, path: Path) => void;
+      push(path: Path[, state: LocationState]) => void;
+      replace(path: Path[, state: LocationState]) => void;
       go(n: number) => void;
       goBack() => void;
       goForward() => void;
@@ -125,7 +127,7 @@ A *query* is the parsed version of a [query string](#querystring).
 
 ### Transition
 
-A *transition* is the process of notifying listeners when the [location](#location) changes. It is not an API; rather, it is a concept. Transitions may be interrupted by [transition hooks](#transitionhook). 
+A *transition* is the process of notifying listeners when the [location](#location) changes. It is not an API; rather, it is a concept. Transitions may be interrupted by [transition hooks](#transitionhook).
 
 Note: A transition does not refer to the exact moment the URL actually changes. For example, in web browsers the user may click the back button or otherwise directly manipulate the URL by typing into the address bar. This is not a transition, but a [history](#history) object will start a transition as a result of the URL changing.
 

--- a/docs/QuerySupport.md
+++ b/docs/QuerySupport.md
@@ -23,9 +23,11 @@ history.listen(function (location) {
 })
 ```
 
-Query-enhanced histories also accept URL queries as trailing arguments to `pushState`, `replaceState`, `createPath`, and `createHref`.
+Query-enhanced histories also accept URL queries as trailing arguments to `pushState`, `replaceState`, `createPath`, `createHref` and as second arguments to `push` and `replace`.
 
 ```js
 history.createPath('/the/path', { the: 'query' })
 history.pushState(null, '/the/path', { the: 'query' })
+history.push('/the/path', { the: 'query' })
+history.replace('/the/path', { the: 'query' }, { the: 'state' })
 ```

--- a/modules/__tests__/BrowserHistory-test.js
+++ b/modules/__tests__/BrowserHistory-test.js
@@ -4,7 +4,9 @@ import createBrowserHistory from '../createBrowserHistory'
 import describeInitialLocation from './describeInitialLocation'
 import describeTransitions from './describeTransitions'
 import describePushState from './describePushState'
+import describePush from './describePush'
 import describeReplaceState from './describeReplaceState'
+import describeReplace from './describeReplace'
 import describePopState from './describePopState'
 import describeHashSupport from './describeHashSupport'
 import describeBasename from './describeBasename'
@@ -20,7 +22,9 @@ describe('browser history', function () {
     describeInitialLocation(createBrowserHistory)
     describeTransitions(createBrowserHistory)
     describePushState(createBrowserHistory)
+    describePush(createBrowserHistory)
     describeReplaceState(createBrowserHistory)
+    describeReplace(createBrowserHistory)
     describePopState(createBrowserHistory)
     describeHashSupport(createBrowserHistory)
     describeBasename(createBrowserHistory)
@@ -31,7 +35,9 @@ describe('browser history', function () {
       describeInitialLocation(createBrowserHistory)
       describeTransitions(createBrowserHistory)
       describePushState(createBrowserHistory)
+      describePush(createBrowserHistory)
       describeReplaceState(createBrowserHistory)
+      describeReplace(createBrowserHistory)
       describePopState(createBrowserHistory)
       describeHashSupport(createBrowserHistory)
       describeBasename(createBrowserHistory)

--- a/modules/__tests__/HashHistory-test.js
+++ b/modules/__tests__/HashHistory-test.js
@@ -5,7 +5,9 @@ import createHashHistory from '../createHashHistory'
 import describeInitialLocation from './describeInitialLocation'
 import describeTransitions from './describeTransitions'
 import describePushState from './describePushState'
+import describePush from './describePush'
 import describeReplaceState from './describeReplaceState'
+import describeReplace from './describeReplace'
 import describePopState from './describePopState'
 import describeQueryKey from './describeQueryKey'
 import describeBasename from './describeBasename'
@@ -21,7 +23,9 @@ describe('hash history', function () {
   describeInitialLocation(createHashHistory)
   describeTransitions(createHashHistory)
   describePushState(createHashHistory)
+  describePush(createHashHistory)
   describeReplaceState(createHashHistory)
+  describeReplace(createHashHistory)
   describePopState(createHashHistory)
   describeBasename(createHashHistory)
   describeQueries(createHashHistory)

--- a/modules/__tests__/MemoryHistory-test.js
+++ b/modules/__tests__/MemoryHistory-test.js
@@ -4,7 +4,9 @@ import createMemoryHistory from '../createMemoryHistory'
 import describeInitialLocation from './describeInitialLocation'
 import describeTransitions from './describeTransitions'
 import describePushState from './describePushState'
+import describePush from './describePush'
 import describeReplaceState from './describeReplaceState'
+import describeReplace from './describeReplace'
 import describeBasename from './describeBasename'
 import describeQueries from './describeQueries'
 import describeGo from './describeGo'
@@ -13,7 +15,9 @@ describe('memory history', function () {
   describeInitialLocation(createMemoryHistory)
   describeTransitions(createMemoryHistory)
   describePushState(createMemoryHistory)
+  describePush(createMemoryHistory)
   describeReplaceState(createMemoryHistory)
+  describeReplace(createMemoryHistory)
   describeBasename(createMemoryHistory)
   describeQueries(createMemoryHistory)
   describeGo(createMemoryHistory)

--- a/modules/__tests__/describePush.js
+++ b/modules/__tests__/describePush.js
@@ -1,0 +1,63 @@
+/*eslint-env mocha */
+import expect from 'expect'
+import { PUSH, POP } from '../Actions'
+import execSteps from './execSteps'
+
+function describePush(createHistory) {
+  describe('push', function () {
+    let history, unlisten
+    beforeEach(function () {
+      history = createHistory()
+    })
+
+    afterEach(function () {
+      if (unlisten)
+        unlisten()
+    })
+
+    it('calls change listeners with the new location', function (done) {
+      let steps = [
+        function (location) {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(POP)
+
+          history.push('/home?the=query', { the: 'state' })
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual({ the: 'state' })
+          expect(location.action).toEqual(PUSH)
+        }
+      ]
+
+      unlisten = history.listen(execSteps(steps, done))
+    })
+
+    it('calls change listeners with the new location without state argument', function (done) {
+      let steps = [
+        function (location) {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(POP)
+
+          history.push('/home?the=query')
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(PUSH)
+        }
+      ]
+
+      unlisten = history.listen(execSteps(steps, done))
+    })
+
+  })
+}
+
+export default describePush

--- a/modules/__tests__/describeQueries.js
+++ b/modules/__tests__/describeQueries.js
@@ -52,6 +52,31 @@ function describeQueries(createHistory) {
       })
     })
 
+    describe('in push', function () {
+      it('works', function (done) {
+        let steps = [
+          function (location) {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.query).toEqual('PARSE_QUERY_STRING')
+            expect(location.state).toEqual(null)
+            expect(location.action).toEqual(POP)
+
+            history.push('/home', { the: 'query' }, { the: 'state' })
+          },
+          function (location) {
+            expect(location.pathname).toEqual('/home')
+            expect(location.search).toEqual('?STRINGIFY_QUERY')
+            expect(location.query).toEqual('PARSE_QUERY_STRING')
+            expect(location.state).toEqual({ the: 'state' })
+            expect(location.action).toEqual(PUSH)
+          }
+        ]
+
+        unlisten = history.listen(execSteps(steps, done))
+      })
+    })
+
     describe('in replaceState', function () {
       it('works', function (done) {
         let steps = [
@@ -63,6 +88,31 @@ function describeQueries(createHistory) {
             expect(location.action).toEqual(POP)
 
             history.replaceState({ the: 'state' }, '/home', { the: 'query' })
+          },
+          function (location) {
+            expect(location.pathname).toEqual('/home')
+            expect(location.search).toEqual('?STRINGIFY_QUERY')
+            expect(location.query).toEqual('PARSE_QUERY_STRING')
+            expect(location.state).toEqual({ the: 'state' })
+            expect(location.action).toEqual(REPLACE)
+          }
+        ]
+
+        unlisten = history.listen(execSteps(steps, done))
+      })
+    })
+
+    describe('in replace', function () {
+      it('works', function (done) {
+        let steps = [
+          function (location) {
+            expect(location.pathname).toEqual('/')
+            expect(location.search).toEqual('')
+            expect(location.query).toEqual('PARSE_QUERY_STRING')
+            expect(location.state).toEqual(null)
+            expect(location.action).toEqual(POP)
+
+            history.replace('/home', { the: 'query' }, { the: 'state' })
           },
           function (location) {
             expect(location.pathname).toEqual('/home')

--- a/modules/__tests__/describeReplace.js
+++ b/modules/__tests__/describeReplace.js
@@ -1,0 +1,62 @@
+/*eslint-env mocha */
+import expect from 'expect'
+import { REPLACE, POP } from '../Actions'
+import execSteps from './execSteps'
+
+function describeReplace(createHistory) {
+  describe('replace', function () {
+    let history, unlisten
+    beforeEach(function () {
+      history = createHistory()
+    })
+
+    afterEach(function () {
+      if (unlisten)
+        unlisten()
+    })
+
+    it('calls change listeners with the new location', function (done) {
+      let steps = [
+        function (location) {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(POP)
+
+          history.replace('/home?the=query', { the: 'state' })
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual({ the: 'state' })
+          expect(location.action).toEqual(REPLACE)
+        }
+      ]
+
+      unlisten = history.listen(execSteps(steps, done))
+    })
+
+    it('calls change listeners with the new location without state argument', function (done) {
+      let steps = [
+        function (location) {
+          expect(location.pathname).toEqual('/')
+          expect(location.search).toEqual('')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(POP)
+
+          history.replace('/home?the=query')
+        },
+        function (location) {
+          expect(location.pathname).toEqual('/home')
+          expect(location.search).toEqual('?the=query')
+          expect(location.state).toEqual(null)
+          expect(location.action).toEqual(REPLACE)
+        }
+      ]
+
+      unlisten = history.listen(execSteps(steps, done))
+    })
+  })
+}
+
+export default describeReplace

--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -138,6 +138,14 @@ function createHistory(options={}) {
     )
   }
 
+  function push(path, state) {
+    pushState(state, path)
+  }
+
+  function replace(path, state) {
+    replaceState(state, path)
+  }
+
   function goBack() {
     go(-1)
   }
@@ -207,6 +215,8 @@ function createHistory(options={}) {
     transitionTo,
     pushState,
     replaceState,
+    push,
+    replace,
     go,
     goBack,
     goForward,

--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -70,6 +70,14 @@ function useQueries(createHistory) {
       return history.replaceState(state, appendQuery(path, query))
     }
 
+    function push(path, query, state) {
+      return history.push(appendQuery(path, query), state)
+    }
+
+    function replace(path, query, state) {
+      return history.replace(appendQuery(path, query), state)
+    }
+
     function createPath(path, query) {
       return history.createPath(appendQuery(path, query))
     }
@@ -88,6 +96,8 @@ function useQueries(createHistory) {
       listen,
       pushState,
       replaceState,
+      push,
+      replace,
       createPath,
       createHref,
       createLocation


### PR DESCRIPTION
This allows to omit `state` parameter: `history.pushState(null, '/home') => history.push('/home')`

See #113 for more info.