### PR TITLE
Fail gracefully when security settings prevent access to sessionStorage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## HEAD
+
+- Fail gracefully when Safari security settings prevent access to window.sessionStorage
+
 ## [v1.13.0]
 > Oct 28, 2015
 


### PR DESCRIPTION
This can happen (at least) in iOS 9 Mobile Safari, when "Block Cookies" is set to "Always Block" (https://github.com/angular-translate/angular-translate/issues/629 suggests this has been true since iOS 7.1.2).