### PR TITLE
Fixed bug in code example

### DIFF
--- a/docs/ConfirmingNavigation.md
+++ b/docs/ConfirmingNavigation.md
@@ -5,7 +5,7 @@ Sometimes you may want to prevent the user from going to a different page. For e
 ```js
 history.listenBefore(function (location) {
   if (input.value !== '')
-    return 'Are you sure you want to leave this page?'
+    return confirm('Are you sure you want to leave this page?');
 })
 ```
 


### PR DESCRIPTION
Old example was returning a string instead of a bool. Now prompting for confirmation via confirm, which I assume was the intent of the example.