### PR TITLE
Reduce saveState data in sessionStorage

### DIFF
--- a/modules/DOMStateStorage.js
+++ b/modules/DOMStateStorage.js
@@ -11,7 +11,11 @@ function createKey(key) {
 
 export function saveState(key, state) {
   try {
-    window.sessionStorage.setItem(createKey(key), JSON.stringify(state))
+    if (state == null) {
+      window.sessionStorage.removeItem(createKey(key))
+    } else {
+      window.sessionStorage.setItem(createKey(key), JSON.stringify(state))
+    }
   } catch (error) {
     if (error.name === SecurityError) {
       // Blocking cookies in Chrome/Firefox/Safari throws SecurityError on any

--- a/modules/__tests__/DOMStateStorage-test.js
+++ b/modules/__tests__/DOMStateStorage-test.js
@@ -1,0 +1,17 @@
+import expect from 'expect'
+import { saveState, readState } from '../DOMStateStorage'
+
+describe('dom state storage', function () {
+  it('saves and reads state data', function () {
+    saveState('key1', { id: 1 })
+    expect(readState('key1')).toEqual({ id: 1 })
+
+    saveState('key1', null)
+    expect(readState('key1')).toEqual(null)
+
+    saveState('key2', { id: 2 })
+    expect(readState('key2')).toEqual({ id: 2 })
+
+    expect(readState('key3')).toEqual(null)
+  })
+})


### PR DESCRIPTION
I'm using history with react-router. Thank you for your great work!

I'm using Session Storage wth my app.
So I often confirm the developer console for debugging app data in Session Storage.

history is adding a state to sessionStorage every history changes.
As a result, my Session Storage is filled by history's state regardless of using it.
This behavior makes my debugging hard.

![screen shot 2015-12-07 at 14 01 21](https://cloud.githubusercontent.com/assets/250407/11626667/f051fca6-9d27-11e5-8b47-142c984db6b6.png)

My PR is for that it saves history's state in Session Storage only when history's state is not empty.

Thanks!