### PR TITLE
Silence warnings for deprecations since 1.13

### DIFF
--- a/modules/createHistory.js
+++ b/modules/createHistory.js
@@ -1,4 +1,4 @@
-import warning from 'warning'
+//import warning from 'warning'
 import deepEqual from 'deep-equal'
 import { loopAsync } from './AsyncUtils'
 import { PUSH, REPLACE, POP } from './Actions'
@@ -184,11 +184,11 @@ function createHistory(options={}) {
 
   function createLocation(location, action, key=createKey()) {
     if (typeof action === 'object') {
-      warning(
-        false,
-        'The state (2nd) argument to history.createLocation is deprecated; use a ' +
-        'location descriptor instead'
-      )
+      //warning(
+      //  false,
+      //  'The state (2nd) argument to history.createLocation is deprecated; use a ' +
+      //  'location descriptor instead'
+      //)
 
       if (typeof location === 'string')
         location = parsePath(location)

--- a/modules/createLocation.js
+++ b/modules/createLocation.js
@@ -1,4 +1,4 @@
-import warning from 'warning'
+//import warning from 'warning'
 import { POP } from './Actions'
 import parsePath from './parsePath'
 
@@ -7,11 +7,11 @@ function createLocation(location='/', action=POP, key=null, _fourthArg=null) {
     location = parsePath(location)
 
   if (typeof action === 'object') {
-    warning(
-      false,
-      'The state (2nd) argument to createLocation is deprecated; use a ' +
-      'location descriptor instead'
-    )
+    //warning(
+    //  false,
+    //  'The state (2nd) argument to createLocation is deprecated; use a ' +
+    //  'location descriptor instead'
+    //)
 
     location = { ...location, state: action }
 

--- a/modules/deprecate.js
+++ b/modules/deprecate.js
@@ -1,10 +1,11 @@
-import warning from 'warning'
+//import warning from 'warning'
 
 function deprecate(fn, message) {
-  return function () {
-    warning(false, '[history] ' + message)
-    return fn.apply(this, arguments)
-  }
+  return fn
+  //return function () {
+  //  warning(false, '[history] ' + message)
+  //  return fn.apply(this, arguments)
+  //}
 }
 
 export default deprecate


### PR DESCRIPTION
This PR silences all warnings that were introduced since 1.13 in preparation for a 1.16 release.

Fixes #185