### PR TITLE
Reverse createHref and createPath warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,11 @@
 > Unreleased
 
 - **Bugfix:** Don't throw in memory history when out of history entries ([#170])
+- **Bugfix:** Fix the deprecation warnings on `createPath` and `createHref` ([#189])
 
 [HEAD]: https://github.com/rackt/history/compare/latest...HEAD
 [#170]: https://github.com/rackt/history/pull/170
+[#189]: https://github.com/rackt/history/pull/189
 
 ## [v1.16.0]
 

--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -106,7 +106,7 @@ function useQueries(createHistory) {
 
     function createPath(location, query) {
       warning(
-        query,
+        !query,
         'the query argument to createPath is deprecated; use a location descriptor instead'
       )
       return history.createPath(appendQuery(location, query || location.query))
@@ -114,7 +114,7 @@ function useQueries(createHistory) {
 
     function createHref(location, query) {
       warning(
-        query,
+        !query,
         'the query argument to createHref is deprecated; use a location descriptor instead'
       )
       return history.createHref(appendQuery(location, query || location.query))


### PR DESCRIPTION
These were backwards. We should push a 1.16.1 so I can get rid of all warnings upstream in `react-router`.