### PR TITLE
Silence warnings on createPath and createHref

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,10 +3,12 @@
 
 - **Bugfix:** Don't throw in memory history when out of history entries ([#170])
 - **Bugfix:** Fix the deprecation warnings on `createPath` and `createHref` ([#189])
+- **Bugfix:** Silence deprecation warnings on `createPath` and `createHref` ([#190])
 
 [HEAD]: https://github.com/rackt/history/compare/latest...HEAD
 [#170]: https://github.com/rackt/history/pull/170
 [#189]: https://github.com/rackt/history/pull/189
+[#190]: https://github.com/rackt/history/pull/190
 
 ## [v1.16.0]
 

--- a/modules/useQueries.js
+++ b/modules/useQueries.js
@@ -105,18 +105,10 @@ function useQueries(createHistory) {
     }
 
     function createPath(location, query) {
-      warning(
-        !query,
-        'the query argument to createPath is deprecated; use a location descriptor instead'
-      )
       return history.createPath(appendQuery(location, query || location.query))
     }
 
     function createHref(location, query) {
-      warning(
-        !query,
-        'the query argument to createHref is deprecated; use a location descriptor instead'
-      )
       return history.createHref(appendQuery(location, query || location.query))
     }
 


### PR DESCRIPTION
OK, **this** should be in `1.16.1`. Then we can revert this PR at a later date when we want all the warnings back.