### PR TITLE
Force basename when location doesn't include it

### DIFF
--- a/modules/useBasename.js
+++ b/modules/useBasename.js
@@ -27,7 +27,7 @@ function useBasename(createHistory) {
           if (location.pathname === '')
             location.pathname = '/'
         } else {
-          location.basename = ''
+          location.basename = basename
         }
       }
 


### PR DESCRIPTION
This treats basename as the minimally viable pathname. Combined with a change to redux-simple-router to replace history with the initial location, this will allow for / -> /base/, /foo -> /base/foo/, /base -> /base/, /base/foo -> /base/foo/. As it is now, it's possible for a redux app to run at both / and /base, contrary to expectations.