### PR TITLE
Use spawn instead of execSync

### DIFF
--- a/npm-scripts/postinstall.js
+++ b/npm-scripts/postinstall.js
@@ -1,11 +1,7 @@
-var execSync = require('child_process').execSync
+var spawn = require('child_process').spawn
 var stat = require('fs').stat
-
-function exec(command) {
-  execSync(command, { stdio: [0, 1, 2] })
-}
 
 stat('lib', function (error, stat) {
   if (error || !stat.isDirectory())
-    exec('npm run build')
+    spawn('npm', ['run', 'build'], { stdio: 'inherit' })
 })


### PR DESCRIPTION
This simply uses spawn instead of execSync to support 0.10.x versions of node.