### PR TITLE
Test location.state consistently

### DIFF
--- a/modules/__tests__/describeReplace.js
+++ b/modules/__tests__/describeReplace.js
@@ -28,7 +28,7 @@ function describeReplace(createHistory) {
           function (location) {
             expect(location.pathname).toEqual('/home')
             expect(location.search).toEqual('?the=query')
-            expect(location.state).toEqual()
+            expect(location.state).toEqual(null)
             expect(location.action).toEqual(REPLACE)
           }
         ]


### PR DESCRIPTION
This seemed to cause the tests to fail with newer versions of expect.