### PR TITLE
Specify es2015 modules location with jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "umd"
   ],
   "main": "lib/index",
+  "jsnext:main": "es6/index",
   "repository": {
     "type": "git",
     "url": "https://github.com/rackt/history.git"


### PR DESCRIPTION
This will let to use [rollup](https://github.com/rollup/rollup) more efficiently.