### PR TITLE
Ignore older safari QUOTA_EXCEEDED_ERRs as well

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 [HEAD]: https://github.com/rackt/history/compare/latest...HEAD
 [#221]: https://github.com/rackt/history/issues/221
 
+- Fail gracefully when Safari 5 security settings prevent access to window.sessionStorage
+
 ## [v2.0.0-rc3]
 > Feb 3, 2016
 

--- a/modules/DOMStateStorage.js
+++ b/modules/DOMStateStorage.js
@@ -2,7 +2,11 @@
 import warning from 'warning'
 
 const KeyPrefix = '@@History/'
-const QuotaExceededError = 'QuotaExceededError'
+const QuotaExceededErrors = [
+  'QuotaExceededError',
+  'QUOTA_EXCEEDED_ERR'
+]
+
 const SecurityError = 'SecurityError'
 
 function createKey(key) {
@@ -28,7 +32,7 @@ export function saveState(key, state) {
       return
     }
 
-    if (error.name === QuotaExceededError && window.sessionStorage.length === 0) {
+    if (QuotaExceededErrors.indexOf(error.name) >= 0 && window.sessionStorage.length === 0) {
       // Safari "private mode" throws QuotaExceededError.
       warning(
         false,


### PR DESCRIPTION
Safari 5.1 throws a different error, without this `history` enabled sites don't work at all in safari private browsing.